### PR TITLE
ci: add nix flake and use in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.8.16'
+library 'status-jenkins-lib@v1.9.24'
 
 pipeline {
   agent { label 'linux' }
@@ -21,14 +21,16 @@ pipeline {
   stages {
     stage('Install') {
       steps {
-        sh 'yarn install'
+        script {
+          nix.develop('yarn install')
+        }
       }
     }
 
     stage('Build') {
       steps {
         script {
-          sh 'yarn build'
+          nix.develop('yarn build')
           jenkins.genBuildMetaJSON('build/build.json')
         }
       }
@@ -37,13 +39,15 @@ pipeline {
     stage('Publish') {
       steps {
         sshagent(credentials: ['status-im-auto-ssh']) {
-          sh """
-            ghp-import \
-              -b ${deployBranch()} \
-              -c ${deployDomain()} \
-              -p build
-          """
-         }
+          script {
+            nix.develop("""
+              ghp-import \
+                -b ${deployBranch()} \
+                -c ${deployDomain()} \
+                -p build
+            """)
+          }
+        }
       }
     }
   }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1735563628,
+        "narHash": "sha256-OnSAY7XDSx7CtDoqNh8jwVwh4xNL/2HaJxGjryLWzX8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b134951a4c9f3c995fd7be05f3243f8ecd65d798",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-24.05",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,33 @@
+{
+  description = "Nix flake development shell.";
+
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixos-24.05";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forEachSystem = nixpkgs.lib.genAttrs supportedSystems;
+      pkgsFor = forEachSystem (system: import nixpkgs { inherit system; });
+    in
+    rec {
+      formatter = forEachSystem (system: pkgsFor.${system}.nixpkgs-fmt);
+
+      devShells = forEachSystem (system: {
+        default = pkgsFor.${system}.mkShellNoCC {
+          packages = with pkgsFor.${system}.buildPackages; [
+            yarn # 1.22.22
+            nodejs_20 # v20.15.1
+            ghp-import # 2.1.0
+          ];
+        };
+      });
+    };
+}


### PR DESCRIPTION
Using system tooling can lead to weird behavior of available Node versions, for example this IPv6 resolution error:
```
[3/5] Fetching packages...
error Error: connect EHOSTUNREACH 2606:4700::6810:1922:443
    at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1495:16)
```

fixes: https://github.com/status-im/infra-sites/issues/59
